### PR TITLE
Modified to specifically grab Centos 7 to fix broken dependencies and…

### DIFF
--- a/metermaid/Dockerfile
+++ b/metermaid/Dockerfile
@@ -1,4 +1,4 @@
-From centos:latest
+From centos:7
 RUN yum -y update
 RUN yum -y install wget vim tar epel-release git nc tee tree && yum -y install rtl-sdr python34 python34-mysql python34-pip
 RUN wget https://dl.google.com/go/go1.10.1.linux-amd64.tar.gz
@@ -8,6 +8,7 @@ RUN mkdir -p /app/bin && cd /app/bin
 ENV GOROOT=/usr/local/go
 ENV GOPATH=/projects 
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH:/app/bin/
+RUN ln -s /usr/bin/python3.4 /usr/bin/python3
 COPY code /app/bin/
 RUN python3 -m pip install pymysql
 RUN /usr/local/go/bin/go get github.com/bemasher/rtlamr && /usr/local/go/bin/go get github.com/bemasher/rtlamr-collect

--- a/weather/Dockerfile
+++ b/weather/Dockerfile
@@ -1,4 +1,4 @@
-From centos:latest
+From centos:7
 RUN yum -y update
 RUN yum -y install wget vim tar epel-release git nc && yum -y install rtl-sdr python34 python34-mysql python34-pip
 RUN wget https://dl.google.com/go/go1.10.1.linux-amd64.tar.gz
@@ -9,6 +9,7 @@ ENV GOROOT=/usr/local/go
 ENV GOPATH=/projects 
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH:/app/bin/MeterMaid
 COPY code /app/bin/
+RUN ln -s /usr/bin/python3.4 /usr/bin/python3
 RUN python3 -m pip install pymysql mysql-connector-python simplejson mysql-connector requests
 ENTRYPOINT bash /app/bin/run.sh 
 


### PR DESCRIPTION
… symlink python3.4 to python3 so original scripts work.

This should probably be migrated to the latest Centos, but this at least gets it working again.